### PR TITLE
Fix unbind when el doesn't have parent node

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,9 @@ Vue.directive(name, {
     }
   },
   unbind: function (el) {
-    el.parentNode.removeChild(el);
+    if(el.parentNode) {
+    	el.parentNode.removeChild(el);    
+    }
   }
 })
 


### PR DESCRIPTION
In some cases the `el` to unbind it's the root node, so it doesn't have a parent node which causes an error: `TypeError: Cannot read property 'removeChild' of null`.